### PR TITLE
Updated Elasticsearch default version to 6.8

### DIFF
--- a/cli/Valet/Elasticsearch.php
+++ b/cli/Valet/Elasticsearch.php
@@ -17,7 +17,7 @@ class Elasticsearch
     const ES_V24_VERSION = '2.4';
     const ES_V56_VERSION = '5.6';
     const ES_V68_VERSION = '6.8';
-    const ES_DEFAULT_VERSION = self::ES_V56_VERSION;
+    const ES_DEFAULT_VERSION = self::ES_V68_VERSION;
 
     const SUPPORTED_ES_FORMULAE = [
         self::ES_V24_VERSION => self::ES_FORMULA_NAME . '@' . self::ES_V24_VERSION,


### PR DESCRIPTION
Homebrew no longer provides Elasticsearch 5.6.